### PR TITLE
Expand IPAddress field to match lib330

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -17,7 +17,7 @@ typedef struct {
   long RingKey;
   int32  HeartbeatInt;
   int32  LogFile;
-  char IPAddress[16];
+  char IPAddress[250];
   int32  baseport;
   int32  dataport;
   char serialnumber[40];


### PR DESCRIPTION
Expanding Configuration.IPAddress to match tpar_register.q330id_address to avoid truncating DNS names.

https://gitlab.com/seismic-software/earthworm/-/blob/master/src/libsrc/lib330/libclient.h?ref_type=heads#L135